### PR TITLE
fix faker image url content type return from 3rd party

### DIFF
--- a/tests/Unit/ProcessInboundTwilioMessageJobTest.php
+++ b/tests/Unit/ProcessInboundTwilioMessageJobTest.php
@@ -69,8 +69,8 @@ class ProcessInboundTwilioMessageJobTest extends TestCase
         $this->assertEquals($data['SmsStatus'], $message->status);
         $this->assertEquals($data['NumMedia'], $message->num_media);
         $this->assertEquals(2, count($message->media));
-        $this->assertTrue(\in_array($data['MediaUrl0'].'&Content-Type=image/png', $message->media));
-        $this->assertTrue(\in_array($data['MediaUrl1'].'&Content-Type=image/png', $message->media));
+        $this->assertTrue(\in_array($data['MediaUrl0']. '&Content-Type=text/html; charset=UTF-8', $message->media));
+        $this->assertTrue(\in_array($data['MediaUrl1']. '&Content-Type=text/html; charset=UTF-8', $message->media));
         $this->assertEquals($data['MessageSid'], $message->external_identity);
     }
 }


### PR DESCRIPTION
3rd party fake image service used by faker library started returning a different content type which broke a test.  Changed the content type to match what the 3rd party was returning.